### PR TITLE
Inherit shared pkgdown theming from animovementtemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     testthat (>= 3.0.0)
 Additional_repositories: https://animovement.r-universe.dev
 Config/testthat/edition: 3
+Config/Needs/website: animovement/animovementtemplate
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,24 +2,11 @@ url: http://animovement.dev/animetric/
 home:
   title: "animetric – An R package for calculating movement-based metrics"
 
-authors:
-  - name: "Mikkel Roald‑Arbøl"
-    href: "https://roald-arboel.com"
-
+# Shared navbar (incl. the animovement dropdown + Zulip), theme, and author
+# details are inherited from animovementtemplate.
 template:
   bootstrap: 5
-  light-switch: true
-
-navbar:
-  structure:
-    left:
-      - intro
-      - reference
-      - news
-    right:
-      - search
-      - github
-      - lightswitch
+  package: animovementtemplate
 
 reference:
 - title: "Calculate"


### PR DESCRIPTION
## Summary

Brings the animetric pkgdown site in line with aniframe, anivis, and anicheck by inheriting the shared theming from the `animovementtemplate` package instead of maintaining a bespoke config.

- `_pkgdown.yml`: replaced the package-local `template`, `navbar`, and `authors` blocks with `template.package: animovementtemplate`. The navbar (including the animovement ecosystem dropdown and the Zulip link), the light-switch theme, and the author details are now inherited from the template package, so they live in one place across the ecosystem. The `url`, home title, and `reference` sections remain package-specific.
- `DESCRIPTION`: added `Config/Needs/website: animovement/animovementtemplate` (there was no `Config/Needs/website` line before) so the template package is installed when the site is built.

The existing pkgdown workflow already uses `needs: website` with `local::.`, so the GitHub-remote template installs without any workflow change.

## Note

The previous navbar did not include a Zulip link or the ecosystem dropdown; both are now present via the shared template, standardising this site with the rest of the ecosystem. The old `intro` navbar item had no backing getting-started page, so dropping it does not affect the rendered site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)